### PR TITLE
Fix threading issue with InflectorRules

### DIFF
--- a/NMG.Core/TextFormatter/Inflector.cs
+++ b/NMG.Core/TextFormatter/Inflector.cs
@@ -53,69 +53,75 @@ namespace NMG.Core.TextFormatter
 
         private static void SetRules()
         {
-            _plurals.Clear();
-            _singulars.Clear();
-            _uncountables.Clear();
-            AddPluralRule("$", "s");
-            AddPluralRule("s$", "s");
-            AddPluralRule("(ax|test)is$", "$1es");
-            AddPluralRule("(octop|vir)us$", "$1i");
-            AddPluralRule("(alias|status)$", "$1es");
-            AddPluralRule("(bu)s$", "$1ses");
-            AddPluralRule("(buffal|tomat)o$", "$1oes");
-            AddPluralRule("([ti])um$", "$1a");
-            AddPluralRule("sis$", "ses");
-            AddPluralRule("(?:([^f])fe|([lr])f)$", "$1$2ves");
-            AddPluralRule("(hive)$", "$1s");
-            AddPluralRule("([^aeiouy]|qu)y$", "$1ies");
-            AddPluralRule("(x|ch|ss|sh)$", "$1es");
-            AddPluralRule("(matr|vert|ind)ix|ex$", "$1ices");
-            AddPluralRule("([m|l])ouse$", "$1ice");
-            AddPluralRule("^(ox)$", "$1en");
-            AddPluralRule("(quiz)$", "$1zes");
+            lock (_plurals)
+            {
+                lock (_singulars)
+                {
+                    _plurals.Clear();
+                    _singulars.Clear();
+                    _uncountables.Clear();
+                    AddPluralRule("$", "s");
+                    AddPluralRule("s$", "s");
+                    AddPluralRule("(ax|test)is$", "$1es");
+                    AddPluralRule("(octop|vir)us$", "$1i");
+                    AddPluralRule("(alias|status)$", "$1es");
+                    AddPluralRule("(bu)s$", "$1ses");
+                    AddPluralRule("(buffal|tomat)o$", "$1oes");
+                    AddPluralRule("([ti])um$", "$1a");
+                    AddPluralRule("sis$", "ses");
+                    AddPluralRule("(?:([^f])fe|([lr])f)$", "$1$2ves");
+                    AddPluralRule("(hive)$", "$1s");
+                    AddPluralRule("([^aeiouy]|qu)y$", "$1ies");
+                    AddPluralRule("(x|ch|ss|sh)$", "$1es");
+                    AddPluralRule("(matr|vert|ind)ix|ex$", "$1ices");
+                    AddPluralRule("([m|l])ouse$", "$1ice");
+                    AddPluralRule("^(ox)$", "$1en");
+                    AddPluralRule("(quiz)$", "$1zes");
 
-            AddSingularRule("s$", String.Empty);
-            AddSingularRule("ss$", "ss");
-            AddSingularRule("(n)ews$", "$1ews");
-            AddSingularRule("([ti])a$", "$1um");
-            AddSingularRule("((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$", "$1$2sis");
-            AddSingularRule("(^analy)ses$", "$1sis");
-            AddSingularRule("([^f])ves$", "$1fe");
-            AddSingularRule("(hive)s$", "$1");
-            AddSingularRule("(tive)s$", "$1");
-            AddSingularRule("([lr])ves$", "$1f");
-            AddSingularRule("([^aeiouy]|qu)ies$", "$1y");
-            AddSingularRule("(s)eries$", "$1eries");
-            AddSingularRule("(m)ovies$", "$1ovie");
-            AddSingularRule("(x|ch|ss|sh)es$", "$1");
-            AddSingularRule("([m|l])ice$", "$1ouse");
-            AddSingularRule("(bus)es$", "$1");
-            AddSingularRule("(o)es$", "$1");
-            AddSingularRule("(shoe)s$", "$1");
-            AddSingularRule("(cris|ax|test)es$", "$1is");
-            AddSingularRule("(octop|vir)i$", "$1us");
-            AddSingularRule("(alias|status)$", "$1");
-            AddSingularRule("(alias|status)es$", "$1");
-            AddSingularRule("^(ox)en", "$1");
-            AddSingularRule("(vert|ind)ices$", "$1ex");
-            AddSingularRule("(matr)ices$", "$1ix");
-            AddSingularRule("(quiz)zes$", "$1");
+                    AddSingularRule("s$", String.Empty);
+                    AddSingularRule("ss$", "ss");
+                    AddSingularRule("(n)ews$", "$1ews");
+                    AddSingularRule("([ti])a$", "$1um");
+                    AddSingularRule("((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$", "$1$2sis");
+                    AddSingularRule("(^analy)ses$", "$1sis");
+                    AddSingularRule("([^f])ves$", "$1fe");
+                    AddSingularRule("(hive)s$", "$1");
+                    AddSingularRule("(tive)s$", "$1");
+                    AddSingularRule("([lr])ves$", "$1f");
+                    AddSingularRule("([^aeiouy]|qu)ies$", "$1y");
+                    AddSingularRule("(s)eries$", "$1eries");
+                    AddSingularRule("(m)ovies$", "$1ovie");
+                    AddSingularRule("(x|ch|ss|sh)es$", "$1");
+                    AddSingularRule("([m|l])ice$", "$1ouse");
+                    AddSingularRule("(bus)es$", "$1");
+                    AddSingularRule("(o)es$", "$1");
+                    AddSingularRule("(shoe)s$", "$1");
+                    AddSingularRule("(cris|ax|test)es$", "$1is");
+                    AddSingularRule("(octop|vir)i$", "$1us");
+                    AddSingularRule("(alias|status)$", "$1");
+                    AddSingularRule("(alias|status)es$", "$1");
+                    AddSingularRule("^(ox)en", "$1");
+                    AddSingularRule("(vert|ind)ices$", "$1ex");
+                    AddSingularRule("(matr)ices$", "$1ix");
+                    AddSingularRule("(quiz)zes$", "$1");
 
-            AddIrregularRule("person", "people");
-            AddIrregularRule("man", "men");
-            AddIrregularRule("child", "children");
-            AddIrregularRule("sex", "sexes");
-            AddIrregularRule("tax", "taxes");
-            AddIrregularRule("move", "moves");
+                    AddIrregularRule("person", "people");
+                    AddIrregularRule("man", "men");
+                    AddIrregularRule("child", "children");
+                    AddIrregularRule("sex", "sexes");
+                    AddIrregularRule("tax", "taxes");
+                    AddIrregularRule("move", "moves");
 
-            AddUnknownCountRule("equipment");
-            AddUnknownCountRule("information");
-            AddUnknownCountRule("rice");
-            AddUnknownCountRule("money");
-            AddUnknownCountRule("species");
-            AddUnknownCountRule("series");
-            AddUnknownCountRule("fish");
-            AddUnknownCountRule("sheep");
+                    AddUnknownCountRule("equipment");
+                    AddUnknownCountRule("information");
+                    AddUnknownCountRule("rice");
+                    AddUnknownCountRule("money");
+                    AddUnknownCountRule("species");
+                    AddUnknownCountRule("series");
+                    AddUnknownCountRule("fish");
+                    AddUnknownCountRule("sheep");
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes an index out of bounds exception in `string SetRules(IList<InflectorRule> rules, string word)`, that occurs when generating for a large number of tables. This seems to be caused by the `_plurals` or `_singulars` list being rebuilt on another thread while it is being used. 

There is probably a better way to do this, such as making those lists non-static, but that would necessitate a larger refactor.